### PR TITLE
Update docs and evaluation to simplify policy usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ lerobot-train --config_path=configs/train_<policy>.yaml
 - **Input/Output features**: Specify which observations and actions to use
 - **Training parameters**: Adjust `batch_size`, `steps`, `save_freq`, etc.
 - **Output directory**: Modify `output_dir` to save models elsewhere
-- **WandB settings**: Configure `wandb.enable` and `wandb.project`
+
 
 See [Training Guide](docs/training.md) for complete configuration examples and feature selection strategies.
 
@@ -128,7 +128,6 @@ Evaluate your trained policy on the challenge garments. The framework supports L
 python -m scripts.eval \
     --policy_type lerobot \
     --policy_path outputs/train/act_fold/checkpoints/100000/pretrained_model \
-    --stage release \
     --garment_type "tops_long" \
     --dataset_root Datasets/record/example/record_top_long_release_10/001 \
     --num_episodes 5 \
@@ -139,7 +138,6 @@ python -m scripts.eval \
 # Note: Participants can define their own model loading logic within the policy class. Provides flexibility for participants to implement specialized loading and inference logic.
 python -m scripts.eval \
     --policy_type custom \
-    --stage release \
     --garment_type "tops_long" \
     --num_episodes 5 \
     --enable_cameras \
@@ -153,13 +151,12 @@ python -m scripts.eval \
 | `--policy_type` | Policy type: `lerobot`, `custom` | `lerobot` | All |
 | `--policy_path` | Path to model checkpoint | - | **LeRobot only** |
 | `--dataset_root` | Dataset path (for metadata) | - | **LeRobot only** |
-| `--stage` | Evaluation stage: `release`, `holdout`, `all` | `release` | All |
 | `--garment_type` | Type of garments: `tops_long`, `tops_short`, `trousers_long`, `trousers_short`, `custom` | `tops_long` | All |
 | `--num_episodes` | Episodes per garment | `5` | All |
 | `--max_steps` | Max steps per episode | `600` | All |
 | `--save_video` | Save evaluation videos | `False` | All |
 | `--video_dir` | Directory to save evaluation videos | `outputs/eval_videos` | `--save_video` |
-| `--enable_cameras` | Enable camera rendering | `False` | All |
+| `--enable_cameras` | Enable camera rendering | `True` | All |
 | `--device` | Device for inference: `cpu`, `cuda` | `cuda` | All |
 | `--use_ee_pose` | Use end-effector pose control | `False` | All |
 | `--ee_urdf_path` | Robot URDF for IK solver | `Assets/robots/so101_new_calib.urdf` | `--use_ee_pose` |

--- a/docs/training.md
+++ b/docs/training.md
@@ -4,15 +4,28 @@ This guide covers how to train policies for the LeHome Challenge, including feat
 
 ## Table of Contents
 
-- [1. Quick Start](#1-quick-start)
-- [2. Training with Official Policies](#2-training-with-official-policies)
-  - [2.1 Available Policies](#21-available-policies)
-  - [2.2 Basic Training Command](#22-basic-training-command)
-  - [2.3 Configuration File Structure](#23-configuration-file-structure)
-  - [2.4 Dataset Features](#24-dataset-features)
-  - [2.5 Feature Selection](#25-feature-selection)
-  - [2.6 Training Parameters](#26-training-parameters)
-- [3. Bring Your Own Policy](#3-bring-your-own-policy)
+- [Training Guide](#training-guide)
+  - [Table of Contents](#table-of-contents)
+  - [1. Quick Start](#1-quick-start)
+  - [2. Training with Official Policies](#2-training-with-official-policies)
+    - [2.1 Available Policies](#21-available-policies)
+    - [2.2 Basic Training Command](#22-basic-training-command)
+    - [2.3 Configuration File Structure](#23-configuration-file-structure)
+    - [2.4 Dataset Features](#24-dataset-features)
+    - [2.5 Feature Selection](#25-feature-selection)
+      - [Feature Types](#feature-types)
+      - [Verified Feature Combinations](#verified-feature-combinations)
+      - [Using Partial Cameras](#using-partial-cameras)
+    - [2.6 Training Parameters](#26-training-parameters)
+      - [Dataset Configuration](#dataset-configuration)
+      - [Policy Configuration](#policy-configuration)
+      - [Training Hyperparameters](#training-hyperparameters)
+      - [Output Configuration](#output-configuration)
+      - [WandB Configuration](#wandb-configuration)
+  - [3. Bring Your Own Policy](#3-bring-your-own-policy)
+    - [Quick Reference: Package Structure](#quick-reference-package-structure)
+    - [Example: Custom Policy Configuration](#example-custom-policy-configuration)
+  - [Additional Resources](#additional-resources)
 
 ---
 
@@ -61,11 +74,11 @@ A typical training configuration file looks like this:
 
 ```yaml
 dataset:
-  repo_id: local_dataset_129
-  root: Datasets/record/129
+  repo_id: <repo_name>
+  root: Datasets/<dataset_name>
 
 policy:
-  type: act
+  type: <policy_type>
   device: cuda
   push_to_hub: false
   
@@ -88,15 +101,14 @@ policy:
       type: ACTION
       shape: [12]
 
-output_dir: outputs/train/act_129
+output_dir: outputs/train/<output_name>
 batch_size: 16
 steps: 30000
 save_freq: 10000
 log_freq: 1000
 
 wandb:
-  enable: true
-  project: lerobot_act_129
+  enable: false
 ```
 
 **Key sections:**
@@ -105,7 +117,7 @@ wandb:
 - **policy**: Defines policy type, device, and input/output features
 - **output_dir**: Where to save checkpoints and logs
 - **Training parameters**: batch_size, steps, save_freq, log_freq
-- **wandb**: Weights & Biases logging configuration
+- **wandb**: Weights & Biases logging configuration, enable if needed
 
 ### 2.4 Dataset Features
 
@@ -251,15 +263,15 @@ rename_map:
 
 ```yaml
 dataset:
-  repo_id: local_dataset_001        # Dataset identifier
-  root: Datasets/record/001         # Dataset path
+  repo_id: <repo_name>             # Dataset identifier
+  root: Datasets/<dataset_name>    # Dataset path
 ```
 
 #### Policy Configuration
 
 ```yaml
 policy:
-  type: act                         # Policy type: act, diffusion, smolvla, etc.
+  type: <policy_type>               # Policy type: act, diffusion, smolvla, etc.
   device: cuda                      # Device: cuda or cpu
   push_to_hub: false                # Whether to push to HuggingFace Hub
 ```

--- a/scripts/eval_policy/POLICY_GUIDE.md
+++ b/scripts/eval_policy/POLICY_GUIDE.md
@@ -12,8 +12,8 @@ Evaluate trained LeRobot models (ACT, Diffusion Policy, SmolVLA):
 python -m scripts.eval \
     --policy_type lerobot \
     --policy_path outputs/train/act_fold/checkpoints/100000/pretrained_model \
-    --dataset_root Datasets/record/001 \
-    --stage release \
+    --garment_type "tops_long" \
+    --dataset_root Datasets/record/example/record_top_long_release_10/001 \
     --num_episodes 5 \
     --enable_cameras \
     --device cpu
@@ -28,7 +28,7 @@ python -m scripts.eval \
 
 ---
 
-## Creating Custom Policies
+## Creating Custom Policies (Without using lerobot)
 
 ### Three Simple Steps
 
@@ -85,8 +85,8 @@ from .my_policy import MyPolicy
 
 ```bash
 python -m scripts.eval \
-    --policy_type my_policy \
-    --stage release \
+    --policy_type custom \
+    --garment_type "tops_long" \
     --num_episodes 5 \
     --enable_cameras \
     --device cpu
@@ -101,34 +101,10 @@ Your custom policy must:
 1. ✅ Inherit from `BasePolicy`
 2. ✅ Implement `select_action(observation: Dict) -> np.ndarray`
 3. ✅ Return actions as `float32` numpy array
-4. ✅ Handle action dimensions: (6) single-arm or (12) dual-arm
+4. ✅ Handle action dimensions: (12) dual-arm
 
 Optional:
 - Implement `reset()` to clear temporal buffers
-
----
-
-## Quick Examples
-
-**Test with built-in policies:**
-
-```bash
-# Random policy (evaluates default garments in the release stage)
-python -m scripts.eval --policy_type custom --stage release --garment_type tops_long --num_episodes 1 --enable_cameras --device cpu
-```
-
-**Record evaluation videos:**
-
-```bash
-python -m scripts.eval \
-    --policy_type my_policy \
-    --policy_path models/my_model.pth \
-    --stage release \
-    --save_video \
-    --video_dir outputs/eval_videos \
-    --enable_cameras \
-    --device cpu
-```
 
 ---
 

--- a/scripts/utils/evaluation.py
+++ b/scripts/utils/evaluation.py
@@ -218,13 +218,6 @@ def eval(args: argparse.Namespace, simulation_app: Any) -> None:
             "dataset_root": args.dataset_root,
             "task_description": args.task_description,
         })
-    else:
-        # Custom policy: participants can define their own loading logic
-        # policy_path is optional and only passed if provided
-        if args.policy_path:
-            policy_kwargs.update({
-                "model_path": args.policy_path,
-            })
     
     # Create policy from registry
     policy = PolicyRegistry.create(args.policy_type, **policy_kwargs)


### PR DESCRIPTION
Removed references to the --stage argument and clarified garment_type usage in documentation and evaluation scripts. Updated training and evaluation guides for clarity, improved configuration examples, and simplified policy instantiation logic in evaluation.py by removing unnecessary model_path handling for custom policies.