### PR TITLE
Add headless support to disable keyboard

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -51,6 +51,26 @@ uv pip install -e ./source/lehome
 ```
 
 ---
+###
+If you are using a server, please download the system dependencies.
+
+```bash
+    #step 1
+    apt update
+    apt install -y \
+    libglu1-mesa \
+    libgl1 \
+    libegl1 \
+    libxrandr2 \
+    libxinerama1 \
+    libxcursor1 \
+    libxi6 \
+    libxext6 \
+    libx11-6
+    #step 2
+    export __GLX_VENDOR_LIBRARY_NAME=nvidia
+```
+
 
 ## Next Steps
 

--- a/scripts/eval.py
+++ b/scripts/eval.py
@@ -23,6 +23,10 @@ def main():
         import lehome.tasks.bedroom
         from .utils.evaluation import eval
 
+        if getattr(args, "headless", False):
+            import os
+
+            os.environ["LEHOME_DISABLE_KEYBOARD"] = "1"
         eval(args, simulation_app)
     except Exception as e:
         logger.error(f"Error during evaluation: {e}")

--- a/source/lehome/lehome/devices/__init__.py
+++ b/source/lehome/lehome/devices/__init__.py
@@ -1,6 +1,9 @@
 from .device_base import DeviceBase
 from .lerobot import SO101Leader, BiSO101Leader
-from .keyboard import Se3Keyboard, BiKeyboard
+import os
+
+if os.environ.get("LEHOME_DISABLE_KEYBOARD") != "1":
+    from .keyboard import Se3Keyboard, BiKeyboard
 
 __all__ = [
     "DeviceBase",


### PR DESCRIPTION
Allow running on headless/server environments by making the keyboard device optional. docs/installation.md: add server dependency installation steps and instructions to set the GL vendor env and LEHOME_DISABLE_KEYBOARD. scripts/eval.py: set LEHOME_DISABLE_KEYBOARD=1 when args.headless is true. source/lehome/lehome/devices/__init__.py: conditionally import Se3Keyboard and BiKeyboard only if LEHOME_DISABLE_KEYBOARD is not set, avoiding keyboard/display-related imports on headless systems.