### PR TITLE
Pause World during garment removal to avoid hang

### DIFF
--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -267,7 +267,7 @@ Replay recorded datasets for visualization, verification, or data augmentation. 
 
 ```bash
 python -m scripts.dataset_sim replay \
-    --dataset_root Datasets/record/example/record_top_long_release_10/001 \
+    --dataset_root Datasets/example/pant_long_merged \
     --num_replays 1 \
     --disable_depth \
     --device "cpu" \

--- a/source/lehome/lehome/tasks/bedroom/garment_bi_v2.py
+++ b/source/lehome/lehome/tasks/bedroom/garment_bi_v2.py
@@ -208,7 +208,15 @@ class GarmentEnv(DirectRLEnv):
         """
         if self.object is None:
             return
-
+        
+        # bug: stuck while eval
+        from isaacsim.core.api import World
+        world = World.instance()
+        # bug: stuck while eval
+        was_playing = world.is_playing()
+        if was_playing:
+            world.pause()
+            
         try:
             # Try to get prim_path from object first, then fallback to garment_name-based path
             if hasattr(self.object, "usd_prim_path") and self.object.usd_prim_path:
@@ -248,7 +256,9 @@ class GarmentEnv(DirectRLEnv):
             import traceback
 
             traceback.print_exc()
-
+        # bug: stuck while eval
+        if was_playing:
+            world.play()
         self.object = None
 
     def _pre_physics_step(self, actions: torch.Tensor) -> None:


### PR DESCRIPTION
Update dataset replay path in docs and prevent evaluation hangs in garment_bi_v2 by pausing the Isaac Sim World when manipulating the garment object. The change captures World.instance(), checks is_playing(), pauses the world before the object operations, and resumes playback if it was playing when an exception occurs. Also updates docs dataset_root to Datasets/example/pant_long_merged and includes minor whitespace cleanup.