### PR TITLE
Add bi-gamepad teleop + quick reset support for bimanual garment manipulation task

### DIFF
--- a/scripts/utils/dataset_record.py
+++ b/scripts/utils/dataset_record.py
@@ -48,7 +48,9 @@ def validate_task_and_device(args: argparse.Namespace) -> None:
         assert (
             args.teleop_device == "bi-so101leader"
             or args.teleop_device == "bi-keyboard"
-        ), "Only support bi-so101leader or bi-keyboard for bi-arm task"
+            or args.teleop_device == "bi-gamepad"
+            or args.teleop_device == "bi-vision"
+        ), "Only support bi-so101leader, bi-keyboard, bi-gamepad, or bi-vision for bi-arm task"
     else:
         assert (
             args.teleop_device == "so101leader" or args.teleop_device == "keyboard"
@@ -83,9 +85,15 @@ def create_teleop_interface(
         )
     if args.teleop_device == "bi-keyboard":
         return BiKeyboard(env, sensitivity=0.25 * args.sensitivity)
+    if args.teleop_device == "bi-gamepad":
+        from lehome.devices import BiGamepad
+        return BiGamepad(env, sensitivity=0.25 * args.sensitivity)
+    if args.teleop_device == "bi-vision":
+        from lehome.devices import BiVision
+        return BiVision(env, sensitivity=0.25 * args.sensitivity)
     raise ValueError(
         f"Invalid device interface '{args.teleop_device}'. "
-        f"Supported: 'keyboard', 'so101leader', 'bi-so101leader', 'bi-keyboard'."
+        f"Supported: 'keyboard', 'so101leader', 'bi-so101leader', 'bi-keyboard', 'bi-gamepad', 'bi-vision'."
     )
 
 
@@ -113,6 +121,7 @@ def register_teleop_callbacks(
         "success": False,  # N: Success/early termination of current episode
         "remove": False,  # D: Discard current episode
         "abort": False,  # ESC: Abort entire recording process, clear buffer
+        "reset": False,  # R: Quick reset environment/object pose
     }
 
     def on_start():
@@ -139,10 +148,15 @@ def register_teleop_callbacks(
         flags["abort"] = True
         logger.warning("[ESC] Abort recording, clearing the current episode buffer...")
 
+    def on_reset():
+        flags["reset"] = True
+        logger.info("[R] Quick reset requested.")
+
     teleop_interface.add_callback("S", on_start)
     teleop_interface.add_callback("N", on_success)
     teleop_interface.add_callback("D", on_remove)
     teleop_interface.add_callback("ESCAPE", on_abort)
+    teleop_interface.add_callback("R", on_reset)
 
     return flags
 
@@ -310,6 +324,7 @@ def run_idle_phase(
     teleop_interface: Any,
     args: argparse.Namespace,
     count_render: int,
+    flags: Dict[str, bool],
 ) -> Tuple[Optional[Dict[str, Any]], int]:
     """Run idle phase before recording starts.
 
@@ -329,6 +344,13 @@ def run_idle_phase(
 
     actions = teleop_interface.advance()
     object_initial_pose = None
+
+    if flags.get("reset", False):
+        logger.info("[Idle Phase] Applying quick reset...")
+        env.reset()
+        stabilize_garment_after_reset(env, args)
+        object_initial_pose = env.get_all_pose()
+        flags["reset"] = False
 
     if count_render == 0:
         logger.info("[Idle Phase] Initializing observations...")
@@ -424,6 +446,25 @@ def run_recording_phase(
                 dataset.finalize()
                 logger.warning(f"Recording aborted, completed {episode_index} episodes")
                 return object_initial_pose
+
+            if flags.get("reset", False):
+                logger.info(
+                    "[Recording] Quick reset requested; clearing current episode buffer..."
+                )
+                dataset.clear_episode_buffer()
+                try:
+                    env.reset()
+                    stabilize_garment_after_reset(env, args)
+                    object_initial_pose = env.get_all_pose()
+                except Exception as e:
+                    logger.error(
+                        f"[Recording] Failed to reset environment during quick reset: {e}"
+                    )
+                    traceback.print_exc()
+                flags["reset"] = False
+                flags["success"] = False
+                flags["remove"] = False
+                continue
 
             try:
                 dynamic_reset_gripper_effort_limit_sim(env, args.teleop_device)
@@ -583,6 +624,7 @@ def run_live_control_without_record(
     env: DirectRLEnv,
     teleop_interface: Any,
     args: argparse.Namespace,
+    flags: Dict[str, bool],
 ) -> None:
     """Run live teleoperation control without recording.
 
@@ -596,6 +638,13 @@ def run_live_control_without_record(
     """
     dynamic_reset_gripper_effort_limit_sim(env, args.teleop_device)
     actions = teleop_interface.advance()
+
+    if flags.get("reset", False):
+        logger.info("[Live Control] Applying quick reset...")
+        env.reset()
+        stabilize_garment_after_reset(env, args)
+        flags["reset"] = False
+        return
 
     if actions is None:
         current_obs = env._get_observations()
@@ -668,6 +717,7 @@ def record_dataset(args: argparse.Namespace, simulation_app: SimulationApp) -> N
                         teleop_interface,
                         args,
                         count_render,
+                        flags,
                     )
                     if pose is not None:
                         object_initial_pose = pose
@@ -695,7 +745,7 @@ def record_dataset(args: argparse.Namespace, simulation_app: SimulationApp) -> N
                     )
                     break
                 else:
-                    run_live_control_without_record(env, teleop_interface, args)
+                    run_live_control_without_record(env, teleop_interface, args, flags)
     except KeyboardInterrupt:
         logger.warning("\n[Ctrl+C] Interrupt signal detected")
         # If Ctrl+C is pressed during recording, clear the current buffer

--- a/scripts/utils/parser.py
+++ b/scripts/utils/parser.py
@@ -21,7 +21,7 @@ def setup_record_parser(
         "--teleop_device",
         type=str,
         default="keyboard",
-        choices=["keyboard", "bi-keyboard", "so101leader", "bi-so101leader"],
+        choices=["keyboard", "bi-keyboard", "so101leader", "bi-so101leader", "bi-gamepad", "bi-vision"],
         help="Device for interacting with environment",
     )
     parser.add_argument(

--- a/source/lehome/lehome/devices/__init__.py
+++ b/source/lehome/lehome/devices/__init__.py
@@ -5,11 +5,15 @@ import os
 if os.environ.get("LEHOME_DISABLE_KEYBOARD") != "1":
     from .keyboard import Se3Keyboard, BiKeyboard
 
+from .gamepad import BiGamepad
+from .vision import BiVision
+
 __all__ = [
     "DeviceBase",
     "SO101Leader",
     "BiSO101Leader",
     "Se3Keyboard",
     "BiKeyboard",
-    # "XboxController",  # Commented out as it may not exist
+    "BiGamepad",
+    "BiVision",
 ]

--- a/source/lehome/lehome/devices/action_process.py
+++ b/source/lehome/lehome/devices/action_process.py
@@ -74,7 +74,7 @@ def init_action_cfg(action_cfg, device):
             joint_names=["gripper"],
             scale=1.0,
         )
-    elif device in ["bi-keyboard"]:
+    elif device in ["bi-keyboard", "bi-gamepad", "bi-vision"]:
         action_cfg.left_arm_action = mdp.RelativeJointPositionActionCfg(
             asset_name="left_arm",
             joint_names=[

--- a/source/lehome/lehome/devices/gamepad/__init__.py
+++ b/source/lehome/lehome/devices/gamepad/__init__.py
@@ -1,0 +1,1 @@
+from .bi_gamepad import BiGamepad

--- a/source/lehome/lehome/devices/gamepad/bi_gamepad.py
+++ b/source/lehome/lehome/devices/gamepad/bi_gamepad.py
@@ -1,0 +1,411 @@
+import weakref
+import numpy as np
+
+from collections.abc import Callable
+from pynput.keyboard import Listener, Key
+
+import carb
+import omni
+
+from ..device_base import Device
+
+
+class BiGamepad(Device):
+    """Gamepad controller for bimanual SO101.
+
+    Split bimanual mode (both arms at the same time):
+
+        Left side (controls LEFT arm)
+        - Left Stick X/Y     → shoulder_pan / shoulder_lift
+        - D-Pad Up/Down      → elbow_flex
+        - Left Trigger (L2)  → gripper CLOSE (analog)
+        - Left Bumper  (L1)  → gripper OPEN
+
+        Right side (controls RIGHT arm)
+        - Right Stick X/Y    → shoulder_pan / shoulder_lift
+        - Y / A              → elbow_flex
+        - Right Trigger (R2) → gripper CLOSE (analog)
+        - Right Bumper (R1)  → gripper OPEN
+
+        Start control: START / MENU button (or keyboard B).
+        Quick reset: VIEW / BACK button (or keyboard R).
+
+    Recording keys (keyboard):
+        B   → start control
+        S   → start recording
+        N   → mark episode success
+        D   → discard episode
+        ESC → abort recording
+
+    """
+
+    def __init__(self, env, sensitivity: float = 0.05):
+        super().__init__(env)
+        self.sensitivity = sensitivity
+
+        # Disable Isaac's built-in gamepad camera control
+        carb.settings.get_settings().set_bool(
+            "/persistent/app/omniverse/gamepadCameraControl", False
+        )
+
+        self._appwindow = omni.appwindow.get_default_app_window()
+        self._input = carb.input.acquire_input_interface()
+        self._gamepad = self._appwindow.get_gamepad(0)
+        self._gamepad_sub = None
+        self._keyboard_sub = None
+
+        self._left_delta_pos = np.zeros(6)
+        self._right_delta_pos = np.zeros(6)
+
+        self.started = False
+        self._reset_state = False
+
+        # Accepts string keys ("S", "N", "D", "ESCAPE") from register_teleop_callbacks
+        self._additional_callbacks: dict = {}
+
+        self.dead_zone = 0.1
+        self.axis_response_exp = 1.8
+        self.axis_gain = 0.75
+        self.gripper_gain = 1.1
+
+        # Joints: 0=shoulder_pan, 1=shoulder_lift, 2=elbow_flex,
+        #         3=wrist_flex, 4=wrist_roll, 5=gripper
+        self._LEFT_INPUT_MAPPING = {}
+        self._RIGHT_INPUT_MAPPING = {}
+        # Stick directions tuned for current camera side.
+        self._bind_gamepad("LEFT_STICK_RIGHT", self._LEFT_INPUT_MAPPING, 0, -1)
+        self._bind_gamepad("LEFT_STICK_LEFT", self._LEFT_INPUT_MAPPING, 0, 1)
+        self._bind_gamepad("LEFT_STICK_UP", self._LEFT_INPUT_MAPPING, 1, 1)
+        self._bind_gamepad("LEFT_STICK_DOWN", self._LEFT_INPUT_MAPPING, 1, -1)
+        # Left elbow on left-side D-pad.
+        self._bind_gamepad("DPAD_UP", self._LEFT_INPUT_MAPPING, 2, 1)
+        self._bind_gamepad("DPAD_DOWN", self._LEFT_INPUT_MAPPING, 2, -1)
+        # Left D-pad horizontal controls wrist_flex by default.
+        self._bind_gamepad("DPAD_LEFT", self._LEFT_INPUT_MAPPING, 3, -1)
+        self._bind_gamepad("DPAD_RIGHT", self._LEFT_INPUT_MAPPING, 3, 1)
+        self._bind_gamepad("LEFT_TRIGGER", self._LEFT_INPUT_MAPPING, 5, -1)  # close
+        self._bind_gamepad_any(("LEFT_BUMPER", "LEFT_SHOULDER"), self._LEFT_INPUT_MAPPING, 5, 1)  # open
+
+        self._bind_gamepad("RIGHT_STICK_RIGHT", self._RIGHT_INPUT_MAPPING, 0, -1)
+        self._bind_gamepad("RIGHT_STICK_LEFT", self._RIGHT_INPUT_MAPPING, 0, 1)
+        self._bind_gamepad("RIGHT_STICK_UP", self._RIGHT_INPUT_MAPPING, 1, 1)
+        self._bind_gamepad("RIGHT_STICK_DOWN", self._RIGHT_INPUT_MAPPING, 1, -1)
+        self._bind_gamepad("Y", self._RIGHT_INPUT_MAPPING, 2, 1)
+        self._bind_gamepad("A", self._RIGHT_INPUT_MAPPING, 2, -1)
+        # Right face buttons (Square/Circle on PS, X/B on Xbox) control wrist_flex.
+        self._bind_gamepad("X", self._RIGHT_INPUT_MAPPING, 3, 1)
+        self._bind_gamepad("B", self._RIGHT_INPUT_MAPPING, 3, -1)
+        self._bind_gamepad("RIGHT_TRIGGER", self._RIGHT_INPUT_MAPPING, 5, -1)  # close
+        self._bind_gamepad_any(("RIGHT_BUMPER", "RIGHT_SHOULDER"), self._RIGHT_INPUT_MAPPING, 5, 1)  # open
+
+        self._current_left_values: dict = {k: 0.0 for k in self._LEFT_INPUT_MAPPING}
+        self._current_right_values: dict = {k: 0.0 for k in self._RIGHT_INPUT_MAPPING}
+        # Shoulder button is used for both gripper-open and wrist-rotation combo.
+        self._left_shoulder_input = self._get_gamepad_input_any(
+            ("LEFT_BUMPER", "LEFT_SHOULDER")
+        )
+        self._right_shoulder_input = self._get_gamepad_input_any(
+            ("RIGHT_BUMPER", "RIGHT_SHOULDER")
+        )
+        self._left_wrist_combo_inputs = {
+            i
+            for i in (
+                getattr(carb.input.GamepadInput, "DPAD_LEFT", None),
+                getattr(carb.input.GamepadInput, "DPAD_RIGHT", None),
+            )
+            if i is not None
+        }
+        self._right_wrist_combo_inputs = {
+            i
+            for i in (
+                getattr(carb.input.GamepadInput, "X", None),
+                getattr(carb.input.GamepadInput, "B", None),
+            )
+            if i is not None
+        }
+
+        # Support different controller backends naming start/menu button.
+        self._start_inputs = []
+        for name in ("START", "MENU"):
+            gamepad_input = getattr(carb.input.GamepadInput, name, None)
+            if gamepad_input is not None:
+                self._start_inputs.append(gamepad_input)
+        # Use view/back for quick reset.
+        self._reset_inputs = []
+        for name in ("VIEW", "BACK"):
+            gamepad_input = getattr(carb.input.GamepadInput, name, None)
+            if gamepad_input is not None:
+                self._reset_inputs.append(gamepad_input)
+        self._reset_input_pressed = {inp: False for inp in self._reset_inputs}
+
+        # Subscribe only after all state is fully initialized.
+        self._gamepad_sub = self._input.subscribe_to_gamepad_events(
+            self._gamepad,
+            lambda event, *args, obj=weakref.proxy(self): obj._on_gamepad_event(event, *args),
+        )
+
+        # Keyboard subscription so B/S/N/D/ESC work on XWayland too
+        # (pynput global key-grabs are blocked by the Wayland compositor).
+        self._keyboard = self._appwindow.get_keyboard()
+        self._keyboard_sub = self._input.subscribe_to_keyboard_events(
+            self._keyboard,
+            lambda event, *args, obj=weakref.proxy(self): obj._on_keyboard_event(event, *args),
+        )
+
+        # Keyboard listener for B/S/N/D/ESC — mirrors BiKeyboard behaviour
+        self._listener = Listener(on_release=self._on_key_release)
+        self._listener.daemon = True
+        self._listener.start()
+
+    def __del__(self):
+        if hasattr(self, "_keyboard_sub") and self._keyboard_sub is not None:
+            self._input.unsubscribe_from_keyboard_events(self._keyboard, self._keyboard_sub)
+            self._keyboard_sub = None
+        if hasattr(self, "_gamepad_sub") and self._gamepad_sub is not None:
+            self._input.unsubscribe_from_gamepad_events(self._gamepad, self._gamepad_sub)
+            self._gamepad_sub = None
+        if hasattr(self, "_listener") and self._listener.running:
+            self._listener.stop()
+
+    def __str__(self) -> str:
+        msg = "Bi-Gamepad Controller for SE(3).\n"
+        try:
+            msg += f"\tDevice: {self._input.get_gamepad_name(self._gamepad)}\n"
+        except Exception:
+            msg += "\tDevice: Unknown Gamepad\n"
+        msg += "\t----------------------------------------------\n"
+        msg += "\tLeft side → LEFT arm\n"
+        msg += "\t  Left Stick X/Y    → shoulder_pan / shoulder_lift\n"
+        msg += "\t  D-Pad Up/Down     → elbow_flex + / -\n"
+        msg += "\t  D-Pad Left/Right  → wrist_flex + / -\n"
+        msg += "\t  Hold L1 + D-Pad Left/Right → wrist_roll + / -\n"
+        msg += "\t  L2 / L1           → gripper close / open\n"
+        msg += "\tRight side → RIGHT arm\n"
+        msg += "\t  Right Stick X/Y   → shoulder_pan / shoulder_lift\n"
+        msg += "\t  Y / A             → elbow_flex + / -\n"
+        msg += "\t  X / B             → wrist_flex + / - (Square / Circle on PS)\n"
+        msg += "\t  Hold R1 + X/B     → wrist_roll + / - (R1 + Square/Circle on PS)\n"
+        msg += "\t  R2 / R1           → gripper close / open\n"
+        msg += "\tSTART/MENU          → start control\n"
+        msg += "\tVIEW/BACK           → quick reset garment/env\n"
+        msg += "\t----------------------------------------------\n"
+        msg += "\tKeyboard B   → start control\n"
+        msg += "\tKeyboard R   → quick reset garment/env\n"
+        msg += "\tKeyboard S   → start recording\n"
+        msg += "\tKeyboard N   → mark success\n"
+        msg += "\tKeyboard D   → discard episode\n"
+        msg += "\tKeyboard ESC → abort\n"
+        return msg
+
+    # ------------------------------------------------------------------
+    # carb.input keyboard handler (B/S/N/D/ESC — works on XWayland)
+    # ------------------------------------------------------------------
+
+    def _on_keyboard_event(self, event, *args, **kwargs):
+        try:
+            key_name = event.input.name if not isinstance(event.input, str) else event.input
+        except AttributeError:
+            return True
+        if event.type == carb.input.KeyboardEventType.KEY_RELEASE:
+            if key_name == "B":
+                self.started = True
+                print("[BiGamepad] Control started! (keyboard B)")
+            elif key_name == "R" and "R" in self._additional_callbacks:
+                self._additional_callbacks["R"]()
+            elif key_name == "S" and "S" in self._additional_callbacks:
+                self._additional_callbacks["S"]()
+            elif key_name == "N" and "N" in self._additional_callbacks:
+                self._additional_callbacks["N"]()
+            elif key_name == "D" and "D" in self._additional_callbacks:
+                self._additional_callbacks["D"]()
+            elif key_name == "ESCAPE" and "ESCAPE" in self._additional_callbacks:
+                self._additional_callbacks["ESCAPE"]()
+        return True
+
+    # ------------------------------------------------------------------
+    # pynput keyboard listener (fallback for non-XWayland systems)
+    # ------------------------------------------------------------------
+
+    def _on_key_release(self, key):
+        try:
+            char = key.char
+            if char == "b":
+                self.started = True
+                print("[BiGamepad] Control started! (keyboard B)")
+            elif char == "r" and "R" in self._additional_callbacks:
+                self._additional_callbacks["R"]()
+            elif char == "s" and "S" in self._additional_callbacks:
+                self._additional_callbacks["S"]()
+            elif char == "n" and "N" in self._additional_callbacks:
+                self._additional_callbacks["N"]()
+            elif char == "d" and "D" in self._additional_callbacks:
+                self._additional_callbacks["D"]()
+        except AttributeError:
+            if key == Key.esc and "ESCAPE" in self._additional_callbacks:
+                self._additional_callbacks["ESCAPE"]()
+
+    # ------------------------------------------------------------------
+    # Gamepad event handler
+    # ------------------------------------------------------------------
+
+    def _on_gamepad_event(self, event, *args, **kwargs):
+        if not hasattr(self, "_start_inputs"):
+            # Guard against callbacks fired during partial init/teardown.
+            return True
+        cur_val = event.value
+
+        # Start control from dedicated controller start/menu buttons.
+        if event.input in self._start_inputs:
+            if cur_val > 0.5:
+                self.started = True
+                print("[BiGamepad] Control started!")
+        # Quick environment reset from controller view/back button.
+        if event.input in self._reset_inputs:
+            was_pressed = self._reset_input_pressed.get(event.input, False)
+            is_pressed = cur_val > 0.5
+            self._reset_input_pressed[event.input] = is_pressed
+            if is_pressed and not was_pressed and "R" in self._additional_callbacks:
+                self._additional_callbacks["R"]()
+
+        # Apply dead zone to continuous inputs (sticks & triggers)
+        if abs(cur_val) < self.dead_zone:
+            cur_val = 0.0
+
+        # Convenience: if control wasn't started yet, any meaningful gamepad
+        # input starts teleop (avoids requiring keyboard "B").
+        if (
+            not self.started
+            and abs(cur_val) > 0.0
+            and (
+                event.input in self._LEFT_INPUT_MAPPING
+                or event.input in self._RIGHT_INPUT_MAPPING
+            )
+        ):
+            self.started = True
+            print("[BiGamepad] Control started! (auto from gamepad input)")
+
+        if event.input in self._LEFT_INPUT_MAPPING:
+            self._current_left_values[event.input] = cur_val
+        elif event.input in self._RIGHT_INPUT_MAPPING:
+            self._current_right_values[event.input] = cur_val
+
+        return True
+
+    def _bind_gamepad(self, name: str, mapping: dict, axis_idx: int, sign: int):
+        gamepad_input = getattr(carb.input.GamepadInput, name, None)
+        if gamepad_input is not None:
+            mapping[gamepad_input] = (axis_idx, sign)
+
+    def _bind_gamepad_any(self, names: tuple[str, ...], mapping: dict, axis_idx: int, sign: int):
+        for name in names:
+            gamepad_input = getattr(carb.input.GamepadInput, name, None)
+            if gamepad_input is not None:
+                mapping[gamepad_input] = (axis_idx, sign)
+                return
+
+    def _get_gamepad_input_any(self, names: tuple[str, ...]):
+        for name in names:
+            gamepad_input = getattr(carb.input.GamepadInput, name, None)
+            if gamepad_input is not None:
+                return gamepad_input
+        return None
+
+    # ------------------------------------------------------------------
+    # Device interface
+    # ------------------------------------------------------------------
+
+    def get_device_state(self):
+        return {
+            "left_arm":  self._left_delta_pos.copy(),
+            "right_arm": self._right_delta_pos.copy(),
+        }
+
+    def input2action(self):
+        left_delta = np.zeros(6)
+        right_delta = np.zeros(6)
+        left_shoulder_pressed = (
+            self._left_shoulder_input is not None
+            and self._current_left_values.get(self._left_shoulder_input, 0.0) > 0.5
+        )
+        right_shoulder_pressed = (
+            self._right_shoulder_input is not None
+            and self._current_right_values.get(self._right_shoulder_input, 0.0) > 0.5
+        )
+
+        for g_input, (axis_idx, sign) in self._LEFT_INPUT_MAPPING.items():
+            val = self._current_left_values[g_input]
+            if val > 0:
+                gain = self.gripper_gain if axis_idx == 5 else self.axis_gain
+                shaped = (val ** self.axis_response_exp) * gain
+                target_axis = axis_idx
+                # L1 + D-pad Left/Right controls wrist_roll instead of wrist_flex.
+                if (
+                    left_shoulder_pressed
+                    and g_input in self._left_wrist_combo_inputs
+                    and axis_idx == 3
+                ):
+                    target_axis = 4
+                # Combo takes priority: don't also issue gripper-open when using it.
+                if (
+                    left_shoulder_pressed
+                    and self._left_shoulder_input is not None
+                    and g_input == self._left_shoulder_input
+                ):
+                    combo_active = any(
+                        self._current_left_values.get(i, 0.0) > 0.05
+                        for i in self._left_wrist_combo_inputs
+                    )
+                    if combo_active:
+                        continue
+                left_delta[target_axis] += sign * shaped * self.sensitivity
+
+        for g_input, (axis_idx, sign) in self._RIGHT_INPUT_MAPPING.items():
+            val = self._current_right_values[g_input]
+            if val > 0:
+                gain = self.gripper_gain if axis_idx == 5 else self.axis_gain
+                shaped = (val ** self.axis_response_exp) * gain
+                target_axis = axis_idx
+                # R1 + X/B (Square/Circle) controls wrist_roll.
+                if (
+                    right_shoulder_pressed
+                    and g_input in self._right_wrist_combo_inputs
+                    and axis_idx == 3
+                ):
+                    target_axis = 4
+                if (
+                    right_shoulder_pressed
+                    and self._right_shoulder_input is not None
+                    and g_input == self._right_shoulder_input
+                ):
+                    combo_active = any(
+                        self._current_right_values.get(i, 0.0) > 0.05
+                        for i in self._right_wrist_combo_inputs
+                    )
+                    if combo_active:
+                        continue
+                right_delta[target_axis] += sign * shaped * self.sensitivity
+
+        self._left_delta_pos = left_delta
+        self._right_delta_pos = right_delta
+
+        ac_dict = {
+            "reset":       self._reset_state,
+            "started":     self.started,
+            "bi_keyboard": True,
+        }
+        if self._reset_state:
+            self._reset_state = False
+            return ac_dict
+
+        ac_dict["joint_state"] = self.get_device_state()
+        return ac_dict
+
+    def reset(self):
+        self._left_delta_pos = np.zeros(6)
+        self._right_delta_pos = np.zeros(6)
+        self._current_left_values = {k: 0.0 for k in self._LEFT_INPUT_MAPPING}
+        self._current_right_values = {k: 0.0 for k in self._RIGHT_INPUT_MAPPING}
+
+    def add_callback(self, key: str, func: Callable):
+        """Register a string-keyed callback (e.g. 'S', 'N', 'D', 'ESCAPE')."""
+        self._additional_callbacks[key] = func

--- a/source/lehome/lehome/devices/keyboard/bi_keyboard.py
+++ b/source/lehome/lehome/devices/keyboard/bi_keyboard.py
@@ -36,6 +36,18 @@ class BiKeyboard(Device):
         Joint 5 (wrist_roll)           9                 0
         Joint 6 (gripper)              [ (or Numpad+)    ] (or Numpad-)
         ============================== ================= =================
+
+        Right Arm (laptop fallback keys):
+        ============================== ================= =================
+        Description                    Key (+ve axis)    Key (-ve axis)
+        ============================== ================= =================
+        Joint 1 (shoulder_pan)         Z                 X
+        Joint 2 (shoulder_lift)        C                 V
+        Joint 3 (elbow_flex)           M                 ,
+        Joint 4 (wrist_flex)           .                 /
+        Joint 5 (wrist_roll)           R                 F
+        Joint 6 (gripper)              W                 E
+        ============================== ================= =================
     """
 
     def __init__(self, env, sensitivity: float = 0.05):
@@ -69,6 +81,7 @@ class BiKeyboard(Device):
         self._additional_callbacks = {}
 
         self.listener = Listener(on_press=self.on_press, on_release=self.on_release)
+        self.listener.daemon = True
         self.listener.start()
 
     def __del__(self):
@@ -96,11 +109,15 @@ class BiKeyboard(Device):
         msg += "\t  Joint 4 (wrist_flex):    7/8\n"
         msg += "\t  Joint 5 (wrist_roll):    9/0\n"
         msg += "\t  Joint 6 (gripper):       [/] (or Numpad +/-)\n"
+        msg += "\t  Laptop fallback set:\n"
+        msg += "\t    J1: Z/X, J2: C/V, J3: M/COMMA, J4: PERIOD/SLASH\n"
+        msg += "\t    J5: R/F, J6: W/E\n"
         msg += "\t----------------------------------------------\n"
         msg += "\tStart Control: B\n"
         msg += "\tStart Recording: S\n"
         msg += "\tDiscard Episode: D\n"
         msg += "\tTask Success and Save: N\n"
+        msg += "\tQuick Reset: R\n"
         msg += "\tAbort Recording: ESC\n"
         msg += "\tControl+C: quit"
         return msg
@@ -131,6 +148,9 @@ class BiKeyboard(Device):
                 # This allows continuous recording of multiple episodes without reactivating control
                 if "N" in self._additional_callbacks:
                     self._additional_callbacks["N"]()
+            elif key.char == "r":
+                if "R" in self._additional_callbacks:
+                    self._additional_callbacks["R"]()
         except AttributeError:
             # Handle special keys (like ESC)
             if key == Key.esc and "ESCAPE" in self._additional_callbacks:
@@ -176,6 +196,7 @@ class BiKeyboard(Device):
                 key_name = event.input.name
         except AttributeError:
             return True
+        key_name = self._normalize_key_name(key_name)
 
         # Apply the command when pressed
         if event.type == carb.input.KeyboardEventType.KEY_PRESS:
@@ -183,13 +204,58 @@ class BiKeyboard(Device):
                 self._left_delta_pos += self._LEFT_KEY_MAPPING[key_name]
             elif key_name in self._RIGHT_KEY_MAPPING.keys():
                 self._right_delta_pos += self._RIGHT_KEY_MAPPING[key_name]
-        # Remove the command when un-pressed
+        # Remove the command when un-pressed; also handle control keys here so
+        # they work on XWayland where pynput global key-grabs are blocked.
         elif event.type == carb.input.KeyboardEventType.KEY_RELEASE:
-            if key_name in self._LEFT_KEY_MAPPING.keys():
+            if key_name == "B":
+                if not self.started:
+                    self.started = True
+                    self._reset_state = False
+                    print("[BiKeyboard] Control started!")
+            elif key_name == "S" and "S" in self._additional_callbacks:
+                self._additional_callbacks["S"]()
+            elif key_name == "N" and "N" in self._additional_callbacks:
+                self._additional_callbacks["N"]()
+            elif key_name == "D" and "D" in self._additional_callbacks:
+                self._additional_callbacks["D"]()
+            elif key_name == "R" and "R" in self._additional_callbacks:
+                self._additional_callbacks["R"]()
+            elif key_name == "ESCAPE" and "ESCAPE" in self._additional_callbacks:
+                self._additional_callbacks["ESCAPE"]()
+            elif key_name in self._LEFT_KEY_MAPPING.keys():
                 self._left_delta_pos -= self._LEFT_KEY_MAPPING[key_name]
             elif key_name in self._RIGHT_KEY_MAPPING.keys():
                 self._right_delta_pos -= self._RIGHT_KEY_MAPPING[key_name]
         return True
+
+    @staticmethod
+    def _normalize_key_name(key_name: str) -> str:
+        """Normalize key names from different backends/layouts to a common form."""
+        if not isinstance(key_name, str):
+            return key_name
+        name = key_name.upper()
+        if name.startswith("KEY_"):
+            # KEY_T -> T, KEY_1 -> 1
+            name = name[4:]
+        return {
+            "ESC": "ESCAPE",
+            "BRACKETLEFT": "LEFT_BRACKET",
+            "BRACKETRIGHT": "RIGHT_BRACKET",
+            "LBRACKET": "LEFT_BRACKET",
+            "RBRACKET": "RIGHT_BRACKET",
+            "NUMPAD_PLUS": "NUMPAD_ADD",
+            "NUMPAD_MINUS": "NUMPAD_SUBTRACT",
+            "KP_ADD": "NUMPAD_ADD",
+            "KP_SUBTRACT": "NUMPAD_SUBTRACT",
+            "ADD": "NUMPAD_ADD",
+            "SUBTRACT": "NUMPAD_SUBTRACT",
+            "+": "NUMPAD_ADD",
+            "-": "NUMPAD_SUBTRACT",
+            "COMMA": "COMMA",
+            "PERIOD": "PERIOD",
+            "DOT": "PERIOD",
+            "SLASH": "SLASH",
+        }.get(name, name)
 
     def _create_key_bindings(self):
         """Creates key bindings for left and right arms."""
@@ -212,28 +278,38 @@ class BiKeyboard(Device):
         # Right arm (number keys) - Supports both main keyboard and numpad
         self._RIGHT_KEY_MAPPING = {
             # Joint 1 (shoulder_pan): 1(+) / 2(-)
+            "1": np.asarray([1.0, 0.0, 0.0, 0.0, 0.0, 0.0]) * self.sensitivity,
             "KEY_1": np.asarray([1.0, 0.0, 0.0, 0.0, 0.0, 0.0]) * self.sensitivity,
             "NUMPAD_1": np.asarray([1.0, 0.0, 0.0, 0.0, 0.0, 0.0]) * self.sensitivity,
+            "2": np.asarray([-1.0, 0.0, 0.0, 0.0, 0.0, 0.0]) * self.sensitivity,
             "KEY_2": np.asarray([-1.0, 0.0, 0.0, 0.0, 0.0, 0.0]) * self.sensitivity,
             "NUMPAD_2": np.asarray([-1.0, 0.0, 0.0, 0.0, 0.0, 0.0]) * self.sensitivity,
             # Joint 2 (shoulder_lift): 3(+) / 4(-)
+            "3": np.asarray([0.0, 1.0, 0.0, 0.0, 0.0, 0.0]) * self.sensitivity,
             "KEY_3": np.asarray([0.0, 1.0, 0.0, 0.0, 0.0, 0.0]) * self.sensitivity,
             "NUMPAD_3": np.asarray([0.0, 1.0, 0.0, 0.0, 0.0, 0.0]) * self.sensitivity,
+            "4": np.asarray([0.0, -1.0, 0.0, 0.0, 0.0, 0.0]) * self.sensitivity,
             "KEY_4": np.asarray([0.0, -1.0, 0.0, 0.0, 0.0, 0.0]) * self.sensitivity,
             "NUMPAD_4": np.asarray([0.0, -1.0, 0.0, 0.0, 0.0, 0.0]) * self.sensitivity,
             # Joint 3 (elbow_flex): 5(+) / 6(-)
+            "5": np.asarray([0.0, 0.0, 1.0, 0.0, 0.0, 0.0]) * self.sensitivity,
             "KEY_5": np.asarray([0.0, 0.0, 1.0, 0.0, 0.0, 0.0]) * self.sensitivity,
             "NUMPAD_5": np.asarray([0.0, 0.0, 1.0, 0.0, 0.0, 0.0]) * self.sensitivity,
+            "6": np.asarray([0.0, 0.0, -1.0, 0.0, 0.0, 0.0]) * self.sensitivity,
             "KEY_6": np.asarray([0.0, 0.0, -1.0, 0.0, 0.0, 0.0]) * self.sensitivity,
             "NUMPAD_6": np.asarray([0.0, 0.0, -1.0, 0.0, 0.0, 0.0]) * self.sensitivity,
             # Joint 4 (wrist_flex): 7(+) / 8(-)
+            "7": np.asarray([0.0, 0.0, 0.0, 1.0, 0.0, 0.0]) * self.sensitivity,
             "KEY_7": np.asarray([0.0, 0.0, 0.0, 1.0, 0.0, 0.0]) * self.sensitivity,
             "NUMPAD_7": np.asarray([0.0, 0.0, 0.0, 1.0, 0.0, 0.0]) * self.sensitivity,
+            "8": np.asarray([0.0, 0.0, 0.0, -1.0, 0.0, 0.0]) * self.sensitivity,
             "KEY_8": np.asarray([0.0, 0.0, 0.0, -1.0, 0.0, 0.0]) * self.sensitivity,
             "NUMPAD_8": np.asarray([0.0, 0.0, 0.0, -1.0, 0.0, 0.0]) * self.sensitivity,
             # Joint 5 (wrist_roll): 9(+) / 0(-)
+            "9": np.asarray([0.0, 0.0, 0.0, 0.0, 1.0, 0.0]) * self.sensitivity,
             "KEY_9": np.asarray([0.0, 0.0, 0.0, 0.0, 1.0, 0.0]) * self.sensitivity,
             "NUMPAD_9": np.asarray([0.0, 0.0, 0.0, 0.0, 1.0, 0.0]) * self.sensitivity,
+            "0": np.asarray([0.0, 0.0, 0.0, 0.0, -1.0, 0.0]) * self.sensitivity,
             "KEY_0": np.asarray([0.0, 0.0, 0.0, 0.0, -1.0, 0.0]) * self.sensitivity,
             "NUMPAD_0": np.asarray([0.0, 0.0, 0.0, 0.0, -1.0, 0.0]) * self.sensitivity,
             # Joint 6 (gripper): [ (+) / ] (-)
@@ -241,4 +317,17 @@ class BiKeyboard(Device):
             "NUMPAD_ADD": np.asarray([0.0, 0.0, 0.0, 0.0, 0.0, 1.0]) * self.sensitivity,  # Numpad +
             "RIGHT_BRACKET": np.asarray([0.0, 0.0, 0.0, 0.0, 0.0, -1.0]) * self.sensitivity,  # ] key
             "NUMPAD_SUBTRACT": np.asarray([0.0, 0.0, 0.0, 0.0, 0.0, -1.0]) * self.sensitivity,  # Numpad -
+            # Laptop fallback controls (no numpad required)
+            "Z": np.asarray([1.0, 0.0, 0.0, 0.0, 0.0, 0.0]) * self.sensitivity,
+            "X": np.asarray([-1.0, 0.0, 0.0, 0.0, 0.0, 0.0]) * self.sensitivity,
+            "C": np.asarray([0.0, 1.0, 0.0, 0.0, 0.0, 0.0]) * self.sensitivity,
+            "V": np.asarray([0.0, -1.0, 0.0, 0.0, 0.0, 0.0]) * self.sensitivity,
+            "M": np.asarray([0.0, 0.0, 1.0, 0.0, 0.0, 0.0]) * self.sensitivity,
+            "COMMA": np.asarray([0.0, 0.0, -1.0, 0.0, 0.0, 0.0]) * self.sensitivity,
+            "PERIOD": np.asarray([0.0, 0.0, 0.0, 1.0, 0.0, 0.0]) * self.sensitivity,
+            "SLASH": np.asarray([0.0, 0.0, 0.0, -1.0, 0.0, 0.0]) * self.sensitivity,
+            "R": np.asarray([0.0, 0.0, 0.0, 0.0, 1.0, 0.0]) * self.sensitivity,
+            "F": np.asarray([0.0, 0.0, 0.0, 0.0, -1.0, 0.0]) * self.sensitivity,
+            "W": np.asarray([0.0, 0.0, 0.0, 0.0, 0.0, 1.0]) * self.sensitivity,
+            "E": np.asarray([0.0, 0.0, 0.0, 0.0, 0.0, -1.0]) * self.sensitivity,
         }

--- a/source/lehome/lehome/utils/env_utils.py
+++ b/source/lehome/lehome/utils/env_utils.py
@@ -4,7 +4,7 @@ import math
 
 def dynamic_reset_gripper_effort_limit_sim(env, teleop_device):
     need_to_set = []
-    if teleop_device in ["bi-so101leader", "bi-keyboard"]:
+    if teleop_device in ["bi-so101leader", "bi-keyboard", "bi-gamepad", "bi-vision"]:
         need_to_set = [
             env.scene.articulations["left_arm"],
             env.scene.articulations["right_arm"],


### PR DESCRIPTION
**Title**  
Add bi-gamepad teleop + quick reset support for bimanual garment manipulation task

**Description**  
## Summary
This PR adds gamepad teleoperation for the bimanual garment task and improves teleop usability/stability for data collection workflows.

## What’s included
- Added new `bi-gamepad` teleop device:
  - File: `source/lehome/lehome/devices/gamepad/bi_gamepad.py`
  - Export: `source/lehome/lehome/devices/gamepad/__init__.py`
- Wired `bi-gamepad` into device selection and parser choices:
  - `scripts/utils/parser.py`
  - `scripts/utils/dataset_record.py`
  - `source/lehome/lehome/devices/__init__.py`
- Action pipeline support for gamepad/vision bi-arm relative control:
  - `source/lehome/lehome/devices/action_process.py`
- Quick reset callback support in teleop loop:
  - Keyboard `R`
  - Gamepad `VIEW/BACK`
  - Handled in idle/live/recording phases
  - `scripts/utils/dataset_record.py`
- Keyboard robustness improvements for bi-keyboard key handling and compatibility:
  - `source/lehome/lehome/devices/keyboard/bi_keyboard.py`
- Included `bi-gamepad` and `bi-vision` in gripper effort reset path:
  - `source/lehome/lehome/utils/env_utils.py`

## Gamepad control model (current)
- Split bimanual control (left controls left arm, right controls right arm)
- Gripper:
  - Left: `L2` close / `L1` open
  - Right: `R2` close / `R1` open
- Wrist flex + rotation separation with combos:
  - Right: `X/B` (Square/Circle on PS) for wrist flex, `R1 + X/B` for wrist rotation
  - Left: `D-pad Left/Right` for wrist flex, `L1 + D-pad Left/Right` for wrist rotation
- Start control:
  - Gamepad `START/MENU` or keyboard `B`
- Quick reset:
  - Gamepad `VIEW/BACK` or keyboard `R`

## Notes
- This PR focuses on teleop input behavior and workflow control.
- No cloth/physics parameters were intentionally modified as part of this PR.
- CPU mode remains recommended for garment physics stability in current challenge setup.

## Validation performed
- Local teleop runtime verification for:
  - bi-keyboard start/control/reset
  - bi-gamepad start/control/reset
  - side-correct bimanual mapping and wrist/gripper combos
- Python syntax checks for modified modules (`py_compile`)

## Potential follow-ups (separate PRs)
- Optional per-controller preset profiles (PS/Xbox naming differences)
- Optional calibration utility for axis inversion/deadzone tuning via CLI flags