### PR TITLE
fix: unify garment success check coordinate space across CPU/GPU

### DIFF
--- a/source/lehome/lehome/utils/success_checker_chanllege.py
+++ b/source/lehome/lehome/utils/success_checker_chanllege.py
@@ -37,11 +37,11 @@ def calculate_distance(point_a, point_b):
 
 def get_object_particle_position(particle_object, index_list):
     try:
-        _, mesh_points, _, _ = particle_object.get_current_mesh_points()
+        transformed_mesh_points, _, _, _ = particle_object.get_current_mesh_points()
     except Exception as e1:
         try:
             logger.error(f"Error in get_object_particle_position: {e1}")
-            mesh_points = (
+            transformed_mesh_points = (
                 particle_object._cloth_prim_view.get_world_positions()
                 .squeeze(0)
                 .detach()
@@ -51,7 +51,7 @@ def get_object_particle_position(particle_object, index_list):
         except Exception as e2:
             logger.error(f"Error in get_object_particle_position: {e2}")
             return
-    positions = (mesh_points[index_list] * 100).tolist()
+    positions = (transformed_mesh_points[index_list] * 100).tolist()
     return positions
 
 
@@ -193,7 +193,9 @@ def check_pant_short(p, success_distance):
 @step_interval(interval=50)
 def success_checker_garment_fold(particle_object, garment_type: str):
     check_point_indices = particle_object.check_points  # list[int]
-    success_distance = particle_object.success_distance  # list[int]
+    raw_success_distance = particle_object.success_distance  # list[int]
+    current_scale = float(particle_object.init_scale[0])
+    success_distance = [d * current_scale for d in raw_success_distance]
     p = get_object_particle_position(particle_object, check_point_indices)
 
     if garment_type == "top-long-sleeve" or garment_type == "top-short-sleeve":


### PR DESCRIPTION
The success checker was reading unscaled local-space particle coordinates on CPU (the 2nd return value of get_current_mesh_points), while the GPU returned scaled world-space coordinates.

This caused an inconsistency in distance measurements: distances computed on CPU were effectively in the unscaled space, while GPU measurements were in the scaled world space. As a result, thresholds calibrated using CPU readings did not match the scaled coordinates used on GPU. The discrepancy depends on the scale defined in the JSON configuration, rather than a fixed factor.

Two changes were made in success_checker_chanllege.py:

get_object_particle_position
Use transformed_mesh_points (the 1st return value) instead of mesh_points (the 2nd). This ensures that both CPU and GPU use consistently scaled world-space coordinates.

success_checker_garment_fold
Multiply the JSON thresholds by init_scale[0] at runtime so that the thresholds match the scaled world space used during evaluation.

No dataset or JSON configuration files are modified. Participants only need to git pull the latest code.    