### PR TITLE
Add Docker-based policy type for clean simulation/policy separation

### DIFF
--- a/dummy_docker_policy/Dockerfile
+++ b/dummy_docker_policy/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+RUN pip install --no-cache-dir numpy
+COPY server.py policy.py ./
+EXPOSE 8080
+CMD ["python", "policy.py"]

--- a/dummy_docker_policy/README.md
+++ b/dummy_docker_policy/README.md
@@ -23,6 +23,7 @@ class MyPolicy(BasePolicyServer):
         top   = observation["observation.images.top_rgb"]    # (H, W, 3) uint8
         left  = observation["observation.images.left_rgb"]   # (H, W, 3) uint8
         right = observation["observation.images.right_rgb"]  # (H, W, 3) uint8
+        depth = observation["observation.top_depth"]         # (H, W) uint16, depth in mm
         prev  = observation["action"]                        # (12,) float32, previous action
 
         action = self.model.predict(state, top, left, right)
@@ -66,6 +67,7 @@ Called when the policy needs new actions.
   - `observation.images.top_rgb` — `{"base64": "...", "shape": [H, W, 3], "dtype": "uint8"}`
   - `observation.images.left_rgb` — same format
   - `observation.images.right_rgb` — same format
+  - `observation.top_depth` — `{"base64": "...", "shape": [H, W], "dtype": "uint16"}` (depth in mm)
   - `action` — 12 floats (previous action)
 - Response: `{"actions": [[12 floats], ...]}`
 

--- a/dummy_docker_policy/README.md
+++ b/dummy_docker_policy/README.md
@@ -1,0 +1,68 @@
+# Docker Policy Server
+
+By using this type policy you can completely isolate the policy from the simulator - they run as two separate processes communicating over HTTP.
+
+## Quick Start
+
+**Edit `policy.py`** — that's the only file you need to change. Replace `DummyPolicy` with your own model:
+
+```python
+class MyPolicy(BasePolicyServer):
+    def __init__(self):
+        self.model = load_your_model("checkpoint.pt")
+
+    def reset(self):
+        pass  # clear buffers between episodes
+
+    def infer(self, observation):
+        state = observation["observation.state"]             # (12,) float32, joint angles
+        top   = observation["observation.images.top_rgb"]    # (H, W, 3) uint8
+        left  = observation["observation.images.left_rgb"]   # (H, W, 3) uint8
+        right = observation["observation.images.right_rgb"]  # (H, W, 3) uint8
+        prev  = observation["action"]                        # (12,) float32, previous action
+
+        action = self.model.predict(state, top, left, right)
+        return [action]  # single action, or list of N for action chunking
+```
+
+Then build and run:
+
+```bash
+docker build -t my-policy .
+docker run --rm -p 8080:8080 my-policy
+```
+
+Evaluate (in another terminal):
+
+```bash
+python -m scripts.eval --policy_type docker --garment_type top_long --headless --device cpu --enable_cameras
+```
+
+## Files
+
+| File | Edit? | Description |
+|------|-------|-------------|
+| `policy.py` | **Yes** | Your policy — edit this |
+| `server.py` | No | HTTP server plumbing (handles communication with simulator) |
+| `Dockerfile` | Maybe | Add your dependencies (`RUN pip install torch ...`) |
+
+## Protocol Details
+
+The server (`server.py`) exposes two HTTP POST endpoints. You don't need to change anything in this file to use `policy.py`, but it's here for reference.
+
+### POST /reset
+Called at the start of each episode.
+- Request: `{}`
+- Response: `{"status": "ok"}`
+
+### POST /infer
+Called when the policy needs new actions.
+- Request: observation dict with keys:
+  - `observation.state` — 12 floats (joint angles)
+  - `observation.images.top_rgb` — `{"base64": "...", "shape": [H, W, 3], "dtype": "uint8"}`
+  - `observation.images.left_rgb` — same format
+  - `observation.images.right_rgb` — same format
+  - `action` — 12 floats (previous action)
+- Response: `{"actions": [[12 floats], ...]}`
+
+Return 1 action for per-step inference, or N actions for action chunking (server is called every N steps).

--- a/dummy_docker_policy/README.md
+++ b/dummy_docker_policy/README.md
@@ -1,6 +1,10 @@
 # Docker Policy Server
 
-By using this type policy you can completely isolate the policy from the simulator - they run as two separate processes communicating over HTTP.
+This policy type completely isolates your policy from the simulator — they run as two separate processes communicating over HTTP.
+
+Your policy runs inside a Docker container and only receives observations (images + joint states). It has no access to the simulation internals, reward functions, or success criteria. This makes submissions reproducible and easy to validate: organizers just run your container and evaluate it with the official code.
+
+You don't need the lehome-challenge repo inside your container at all — just your model and a lightweight HTTP server.
 
 ## Quick Start
 

--- a/dummy_docker_policy/policy.py
+++ b/dummy_docker_policy/policy.py
@@ -1,0 +1,49 @@
+"""
+LeHome Challenge — Your Policy.
+
+EDIT THIS FILE to implement your policy.
+
+Replace the DummyPolicy class with your own model logic.
+The server handles all communication — you only need to implement:
+    reset()  — called at the start of each episode
+    infer()  — receives observations, returns actions
+"""
+
+import numpy as np
+from typing import Dict, List
+from server import BasePolicyServer
+
+ACTION_DIM = 12
+CHUNK_SIZE = 10
+
+
+class DummyPolicy(BasePolicyServer):
+    """
+    Dummy policy that returns zero actions.
+
+    Replace this with your own model. For example:
+        def __init__(self):
+            self.model = load_your_model("checkpoint.pt")
+
+        def infer(self, observation):
+            images = observation["observation.images.top_rgb"]   # (H, W, 3) uint8
+            state = observation["observation.state"]             # (12,) float32
+            actions = self.model.predict(images, state)
+            return [actions]  # single action, or list of N for chunking
+    """
+
+    def reset(self):
+        print("  Episode reset")
+
+    def infer(self, observation: Dict[str, np.ndarray]) -> List[np.ndarray]:
+        for key, value in observation.items():
+            print(f"  {key}: shape={value.shape}, dtype={value.dtype}, "
+                  f"min={value.min():.3f}, max={value.max():.3f}")
+
+        actions = [np.zeros(ACTION_DIM, dtype=np.float32) for _ in range(CHUNK_SIZE)]
+        print(f"  -> returning {len(actions)} actions, dim={ACTION_DIM}")
+        return actions
+
+
+if __name__ == "__main__":
+    DummyPolicy().run()

--- a/dummy_docker_policy/server.py
+++ b/dummy_docker_policy/server.py
@@ -1,0 +1,101 @@
+"""
+LeHome Challenge — Policy Server.
+
+DO NOT MODIFY THIS FILE. Edit policy.py instead.
+
+Handles HTTP communication between the simulator and your policy.
+See policy.py for the interface you need to implement.
+"""
+
+import base64
+import json
+import numpy as np
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from typing import Dict, List
+
+
+class BasePolicyServer:
+    """
+    Base class for LeHome policy servers.
+
+    Handles all HTTP plumbing. Subclass and override:
+        reset()              — called at the start of each episode
+        infer(observation)   — called to get the next action chunk
+
+    Observation dict contains:
+        "observation.state"           — np.ndarray, shape (12,), float32 (joint angles)
+        "observation.images.top_rgb"  — np.ndarray, shape (H, W, 3), uint8
+        "observation.images.left_rgb" — np.ndarray, shape (H, W, 3), uint8
+        "observation.images.right_rgb"— np.ndarray, shape (H, W, 3), uint8
+        "action"                      — np.ndarray, shape (12,), float32 (previous action)
+    """
+
+    def reset(self) -> None:
+        """Called at the start of each episode. Override to clear buffers, etc."""
+        pass
+
+    def infer(self, observation: Dict[str, np.ndarray]) -> List[np.ndarray]:
+        """
+        Return a list of actions (action chunk).
+
+        Args:
+            observation: Dict of numpy arrays (state, images, previous action).
+
+        Returns:
+            List of np.ndarray actions, each shape (action_dim,).
+            Return 1 action for per-step control, or N for action chunking.
+        """
+        raise NotImplementedError("Subclass must implement infer()")
+
+    def run(self, host: str = "0.0.0.0", port: int = 8080) -> None:
+        """Start the HTTP server."""
+        policy = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self):
+                content_length = int(self.headers.get("Content-Length", 0))
+                body = self.rfile.read(content_length) if content_length > 0 else b"{}"
+                request = json.loads(body)
+
+                if self.path == "/reset":
+                    policy.reset()
+                    response = {"status": "ok"}
+
+                elif self.path == "/infer":
+                    observation = _deserialize_observation(request)
+                    actions = policy.infer(observation)
+                    response = {"actions": [a.tolist() for a in actions]}
+
+                else:
+                    self.send_error(404, f"Unknown endpoint: {self.path}")
+                    return
+
+                body_bytes = json.dumps(response).encode("utf-8")
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body_bytes)))
+                self.end_headers()
+                self.wfile.write(body_bytes)
+
+            def log_message(self, format, *args):
+                print(f"[{self.command}] {self.path}")
+
+        server = HTTPServer((host, port), Handler)
+        print(f"Policy server listening on {host}:{port}")
+        try:
+            server.serve_forever()
+        except KeyboardInterrupt:
+            print("\nShutting down.")
+            server.server_close()
+
+
+def _deserialize_observation(raw: dict) -> Dict[str, np.ndarray]:
+    """Convert JSON observation to numpy arrays."""
+    observation = {}
+    for key, value in raw.items():
+        if isinstance(value, dict) and "base64" in value:
+            buf = base64.b64decode(value["base64"])
+            observation[key] = np.frombuffer(buf, dtype=value["dtype"]).reshape(value["shape"])
+        elif isinstance(value, list):
+            observation[key] = np.array(value, dtype=np.float32)
+    return observation

--- a/dummy_docker_policy/server.py
+++ b/dummy_docker_policy/server.py
@@ -27,6 +27,7 @@ class BasePolicyServer:
         "observation.images.top_rgb"  — np.ndarray, shape (H, W, 3), uint8
         "observation.images.left_rgb" — np.ndarray, shape (H, W, 3), uint8
         "observation.images.right_rgb"— np.ndarray, shape (H, W, 3), uint8
+        "observation.top_depth"       — np.ndarray, shape (H, W), uint16 (depth in mm)
         "action"                      — np.ndarray, shape (12,), float32 (previous action)
     """
 

--- a/scripts/eval_policy/__init__.py
+++ b/scripts/eval_policy/__init__.py
@@ -11,10 +11,12 @@ from .registry import PolicyRegistry
 # Import policy implementations (this will auto-register them)
 from .lerobot_policy import LeRobotPolicy
 from .example_participant_policy import CustomPolicy
+from .docker_policy import DockerPolicy
 
 __all__ = [
-    "BasePolicy", 
+    "BasePolicy",
     "PolicyRegistry",
-    "LeRobotPolicy", 
-    "CustomPolicy", 
+    "LeRobotPolicy",
+    "CustomPolicy",
+    "DockerPolicy",
 ]

--- a/scripts/eval_policy/docker_policy.py
+++ b/scripts/eval_policy/docker_policy.py
@@ -89,8 +89,8 @@ class DockerPolicy(BasePolicy):
         for key, value in observation.items():
             if not isinstance(value, np.ndarray):
                 continue
-            if "images" in key:
-                # Encode image as base64
+            if "images" in key or "depth" in key:
+                # Images and depth: encode as base64 (much smaller than JSON lists)
                 payload[key] = {
                     "base64": base64.b64encode(value.tobytes()).decode("ascii"),
                     "shape": list(value.shape),

--- a/scripts/eval_policy/docker_policy.py
+++ b/scripts/eval_policy/docker_policy.py
@@ -1,0 +1,117 @@
+"""
+Docker-based Policy for LeHome Challenge.
+
+This policy connects to an external Docker container running a policy server
+over HTTP. The simulation sends observations and receives action chunks,
+cleanly separating simulation logic from policy logic.
+
+Protocol:
+    POST /reset  — called at episode start, body: {}
+    POST /infer  — send observation, receive action chunk
+
+See dummy_docker_policy for a minimal server implementation.
+"""
+
+import base64
+import json
+import numpy as np
+import urllib.request
+import urllib.error
+from typing import Dict, List
+
+from .base_policy import BasePolicy
+from .registry import PolicyRegistry
+
+
+@PolicyRegistry.register("docker")
+class DockerPolicy(BasePolicy):
+    """
+    Policy that delegates inference to an external Docker container via HTTP.
+
+    The container must expose two endpoints:
+        POST /reset  -> {"status": "ok"}
+        POST /infer  -> {"actions": [[12 floats], ...]}
+
+    Action chunking is handled transparently: if the server returns N actions,
+    the next N calls to select_action() use cached actions before re-querying.
+
+    Usage:
+        # Start your policy container first:
+        #   docker run --rm -p 8080:8080 my-policy-image
+        #
+        # Then run evaluation:
+        #   python -m scripts.eval --policy_type docker --docker_url http://localhost:8080
+    """
+
+    def __init__(self, docker_url: str = "http://localhost:8080", **kwargs):
+        super().__init__(**kwargs)
+        self.docker_url = docker_url.rstrip("/")
+        self._action_chunk: List[np.ndarray] = []
+        self._chunk_idx: int = 0
+
+        # Verify server is reachable
+        try:
+            self._post("/reset", {})
+        except Exception as e:
+            raise ConnectionError(
+                f"Cannot connect to policy server at {self.docker_url}. "
+                f"Make sure your Docker container is running. Error: {e}"
+            )
+        print(f"[DockerPolicy] Connected to {self.docker_url}")
+
+    def reset(self):
+        """Reset policy state for a new episode."""
+        self._action_chunk = []
+        self._chunk_idx = 0
+        self._post("/reset", {})
+
+    def select_action(self, observation: Dict[str, np.ndarray]) -> np.ndarray:
+        """
+        Get next action. Queries the server when the cached chunk is exhausted.
+        """
+        if self._chunk_idx >= len(self._action_chunk):
+            # Need a new chunk from the server
+            payload = self._serialize_observation(observation)
+            response = self._post("/infer", payload)
+            actions = response["actions"]
+            self._action_chunk = [
+                np.array(a, dtype=np.float32) for a in actions
+            ]
+            self._chunk_idx = 0
+
+        action = self._action_chunk[self._chunk_idx]
+        self._chunk_idx += 1
+        return action
+
+    def _serialize_observation(self, observation: Dict[str, np.ndarray]) -> dict:
+        """Serialize observation dict to JSON-compatible format."""
+        payload = {}
+        for key, value in observation.items():
+            if not isinstance(value, np.ndarray):
+                continue
+            if "images" in key:
+                # Encode image as base64
+                payload[key] = {
+                    "base64": base64.b64encode(value.tobytes()).decode("ascii"),
+                    "shape": list(value.shape),
+                    "dtype": str(value.dtype),
+                }
+            else:
+                payload[key] = value.tolist()
+        return payload
+
+    def _post(self, endpoint: str, data: dict) -> dict:
+        """Send a POST request and return parsed JSON response."""
+        url = self.docker_url + endpoint
+        body = json.dumps(data).encode("utf-8")
+        req = urllib.request.Request(
+            url,
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=600) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except urllib.error.URLError as e:
+            raise ConnectionError(f"Policy server request failed ({url}): {e}")

--- a/scripts/utils/evaluation.py
+++ b/scripts/utils/evaluation.py
@@ -289,6 +289,9 @@ def eval(args: argparse.Namespace, simulation_app: Any) -> None:
                 "task_description": args.task_description,
             }
         )
+    elif args.policy_type == "docker":
+        # Docker policy connects to an external container
+        policy_kwargs["docker_url"] = args.docker_url
     else:
         # For custom policies, pass policy_path as model_path if provided
         if args.policy_path:

--- a/scripts/utils/parser.py
+++ b/scripts/utils/parser.py
@@ -477,4 +477,12 @@ def setup_eval_parser() -> argparse.ArgumentParser:
         help="URDF path for IK solver (required when --use_ee_pose is set).",
     )
 
+    # Docker policy arguments
+    parser.add_argument(
+        "--docker_url",
+        type=str,
+        default="http://localhost:8080",
+        help="URL of the Docker policy server (used when --policy_type docker).",
+    )
+
     return parser


### PR DESCRIPTION
# Problem
The current submission approach mixes simulation and policy logic in one process. This creates issues on both sides:
- For competitors: simulation and policy share the same environment. If a policy needs a different library version, it adds unnecessary complexity and potential conflicts.
- For organizers: every submission includes both policy and simulation code. This means you need to inspect each submission to ensure the simulation was not altered — no garment type labels leaked, no physics params or success criteria changed, etc. Not necessarily malicious, but things can be changed unintentionally and still impact performance.

# Solution
I propose to completely separate simulation and policy. Participants submit a Docker container that exposes a single HTTP endpoint: receive observations, send back action chunks. The container doesn't need to contain the lehome-challenge repo at all.

To validate a submission, organizers just:
`docker run --rm -p 8080:8080 participant-policy` - using the submitted policy from the competitors 
`python -m scripts.eval --policy_type docker --garment_type top_long --headless --device cpu --enable_cameras` - using the official code from the challenge repo

The policy in the container has zero access to anything except the observations sent by the official evaluation code.

I implemented the policy that can send observations to the specified address and receive back action to execute (action chunks are supported by default).

I also implemented a dummy policy (sends a chunk of 0 actions) in Docker. This example can be used to wrap any policy into a compatible Docker image in just a few lines of code (+ Docker setup, dependencies, etc.)

A short readme is here https://github.com/IliaLarchenko/lehome-challenge/blob/main/dummy_docker_policy/README.md